### PR TITLE
Expand the registrant form by default if there is only

### DIFF
--- a/src/Element/Registrants.php
+++ b/src/Element/Registrants.php
@@ -127,6 +127,10 @@ class Registrants extends FormElement {
     $arity_is_multiple = $utility->getArity() === 'multiple';
     $arity_is_single = !$arity_is_multiple;
     $change_it = $utility->getChangeIt();
+    if(count($for_bundles) == 1){
+      // Show the form directly if it's single persond and only one bundle:
+      $utility->setShowCreateEntitySubform(TRUE);
+    }
     $entity_create_form = $utility->getShowCreateEntitySubform();
 
     if (!$change_it) {


### PR DESCRIPTION
The registrant form can and should be expanded by default if there is only one person type bundle. It saves one click (UX) on the button in this case.
If that should not happen by default in the view of the maintainer there should be at least an option to do this, because it's helpful in many cases where a quick simple registration form is required.