### PR TITLE
Drupal 8.5 compatibility

### DIFF
--- a/src/Routing/Enhancer/RngRouteEnhancer.php
+++ b/src/Routing/Enhancer/RngRouteEnhancer.php
@@ -22,13 +22,13 @@ class RngRouteEnhancer implements RouteEnhancerInterface {
    * {@inheritdoc}
    */
   public function enhance(array $defaults, Request $request) {
-    $event_entity_type = $defaults['event'];
-
-    if (isset($defaults[$event_entity_type])) {
-      $rng_event = $defaults[$event_entity_type];
-      $defaults['rng_event'] = $rng_event;
+    if(!empty($defaults['event'])){
+      $event_entity_type = $defaults['event'];
+      if (isset($defaults[$event_entity_type])) {
+        $rng_event = $defaults[$event_entity_type];
+        $defaults['rng_event'] = $rng_event;
+      }
     }
-
     return $defaults;
   }
 


### PR DESCRIPTION
Don't assume that $defaults['event'] exists. Otherwise routes may break. Fall back to default if it does not exist.